### PR TITLE
Compatibility for Ubuntu 16.04

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,6 +21,7 @@ provisioner:
 
 platforms:
   - name: ubuntu-14.04
+  - name: ubuntu-16.04
   - name: centos-7.2
 
 suites:
@@ -28,6 +29,7 @@ suites:
     run_list:
       - recipe[airflow::default]
     attributes:
+
   - name: airflow-webserver
     run_list:
       - recipe[airflow::default]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -4,7 +4,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 
-#     http//www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -40,4 +40,3 @@ default["airflow"]["config"]["core"]["sql_alchemy_conn"] = "sqlite:///#{node["ai
 default["airflow"]["config"]["core"]["fernet_key"] = "G3jB5--jCQpRYp7hwUtpfQ_S8zLRbRMwX8tr3dehnNU=" # Be sure to change this for production
 # Celery
 default["airflow"]["config"]["celery"]["celeryd_concurrency"] = 16
-

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,6 +27,7 @@ default["airflow"]["config_file_mode"] = "0644"
 default["airflow"]["bin_path"] = node["platform"] == "ubuntu" ? "/usr/local/bin" : "/usr/bin"
 default["airflow"]["run_path"] = "/var/run/airflow"
 default["airflow"]["init_system"] = node["platform"] == "ubuntu" ? "upstart" : "systemd"
+default["airflow"]["env_path"] = node["airflow"]["init_system"] == "upstart" ? "/etc/default/airflow" : "/etc/sysconfig/airflow"
 
 # Configurations stated below are required for this cookbook and will be written to airflow.cfg, you can add more config by using structure like:
 # default["airflow"]["config"]["CONFIG_SECTION"]["CONFIG_ENTRY"]

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,7 +32,7 @@ end
 
 template "airflow_services_env" do
   source "init_system/airflow-env.erb"
-  path node["airflow"]["init_system"] == "upstart" ? "/etc/default/airflow" : "/etc/sysconfig/airflow"
+  path node["airflow"]["env_path"]
   owner "root"
   group "root"
   mode "0644"

--- a/recipes/flower.rb
+++ b/recipes/flower.rb
@@ -15,6 +15,9 @@
 if (node["airflow"]["init_system"] == "upstart") 
   service_target = "/etc/init/airflow-flower.conf"
   service_template = "init_system/upstart/airflow-flower.conf.erb"
+elsif (node["airflow"]["init_system"] == "systemd" && node["platform"] == "ubuntu" )
+  service_target = "/etc/systemd/system/airflow-flower.service"
+  service_template = "init_system/systemd/airflow-flower.service.erb"
 else
   service_target = "/usr/lib/systemd/system/airflow-flower.service"
   service_template = "init_system/systemd/airflow-flower.service.erb"
@@ -29,7 +32,8 @@ template service_target do
     :user => node["airflow"]["user"], 
     :group => node["airflow"]["group"],
     :run_path => node["airflow"]["run_path"],
-    :bin_path => node["airflow"]["bin_path"]
+    :bin_path => node["airflow"]["bin_path"],
+    :env_path => node["airflow"]["env_path"],
   })
 end
 

--- a/recipes/kerberos.rb
+++ b/recipes/kerberos.rb
@@ -15,6 +15,9 @@
 if (node["airflow"]["init_system"] == "upstart") 
   service_target = "/etc/init/airflow-kerberos.conf"
   service_template = "init_system/upstart/airflow-kerberos.conf.erb"
+elsif (node["airflow"]["init_system"] == "systemd" && node["platform"] == "ubuntu" )
+  service_target = "/etc/systemd/system/airflow-kerberos.service"
+  service_template = "init_system/systemd/airflow-kerberos.service.erb"
 else
   service_target = "/usr/lib/systemd/system/airflow-kerberos.service"
   service_template = "init_system/systemd/airflow-kerberos.service.erb"
@@ -29,7 +32,8 @@ template service_target do
     :user => node["airflow"]["user"], 
     :group => node["airflow"]["group"],
     :run_path => node["airflow"]["run_path"],
-    :bin_path => node["airflow"]["bin_path"]
+    :bin_path => node["airflow"]["bin_path"],
+    :env_path => node["airflow"]["env_path"],
   })
 end
 

--- a/recipes/scheduler.rb
+++ b/recipes/scheduler.rb
@@ -15,6 +15,9 @@
 if (node["airflow"]["init_system"] == "upstart") 
   service_target = "/etc/init/airflow-scheduler.conf"
   service_template = "init_system/upstart/airflow-scheduler.conf.erb"
+elsif (node["airflow"]["init_system"] == "systemd" && node["platform"] == "ubuntu" )
+  service_target = "/etc/systemd/system/airflow-scheduler.service"
+  service_template = "init_system/systemd/airflow-scheduler.service.erb"
 else
   service_target = "/usr/lib/systemd/system/airflow-scheduler.service"
   service_template = "init_system/systemd/airflow-scheduler.service.erb"
@@ -29,7 +32,8 @@ template service_target do
     :user => node["airflow"]["user"], 
     :group => node["airflow"]["group"],
     :run_path => node["airflow"]["run_path"],
-    :bin_path => node["airflow"]["bin_path"]
+    :bin_path => node["airflow"]["bin_path"],
+    :env_path => node["airflow"]["env_path"],
   })
 end
 

--- a/recipes/webserver.rb
+++ b/recipes/webserver.rb
@@ -15,6 +15,9 @@
 if (node["airflow"]["init_system"] == "upstart") 
   service_target = "/etc/init/airflow-webserver.conf"
   service_template = "init_system/upstart/airflow-webserver.conf.erb"
+elsif (node["airflow"]["init_system"] == "systemd" && node["platform"] == "ubuntu" )
+  service_target = "/etc/systemd/system/airflow-webserver.service"
+  service_template = "init_system/systemd/airflow-webserver.service.erb"
 else
   service_target = "/usr/lib/systemd/system/airflow-webserver.service"
   service_template = "init_system/systemd/airflow-webserver.service.erb"
@@ -29,7 +32,8 @@ template service_target do
     :user => node["airflow"]["user"], 
     :group => node["airflow"]["group"],
     :run_path => node["airflow"]["run_path"],
-    :bin_path => node["airflow"]["bin_path"]
+    :bin_path => node["airflow"]["bin_path"],
+    :env_path => node["airflow"]["env_path"],
   })
 end
 

--- a/recipes/worker.rb
+++ b/recipes/worker.rb
@@ -15,6 +15,9 @@
 if (node["airflow"]["init_system"] == "upstart") 
   service_target = "/etc/init/airflow-worker.conf"
   service_template = "init_system/upstart/airflow-worker.conf.erb"
+elsif (node["airflow"]["init_system"] == "systemd" && node["platform"] == "ubuntu" )
+  service_target = "/etc/systemd/system/airflow-worker.service"
+  service_template = "init_system/systemd/airflow-worker.service.erb"
 else
   service_target = "/usr/lib/systemd/system/airflow-worker.service"
   service_template = "init_system/systemd/airflow-worker.service.erb"
@@ -29,7 +32,8 @@ template service_target do
     :user => node["airflow"]["user"], 
     :group => node["airflow"]["group"],
     :run_path => node["airflow"]["run_path"],
-    :bin_path => node["airflow"]["bin_path"]
+    :bin_path => node["airflow"]["bin_path"],
+    :env_path => node["airflow"]["env_path"],
   })
 end
 

--- a/templates/default/init_system/systemd/airflow-flower.service.erb
+++ b/templates/default/init_system/systemd/airflow-flower.service.erb
@@ -17,7 +17,7 @@ Description=Airflow flower daemon
 After=network.target
 
 [Service]
-EnvironmentFile=/etc/sysconfig/airflow
+EnvironmentFile=<%= @env_path %>
 User=<%= @user %>
 Group=<%= @group %>
 ExecStart=<%= @bin_path %>/airflow flower --pid <%= @run_path %>/airflow-flower.pid

--- a/templates/default/init_system/systemd/airflow-kerberos.service.erb
+++ b/templates/default/init_system/systemd/airflow-kerberos.service.erb
@@ -17,7 +17,7 @@ Description=Airflow kerberos daemon
 After=network.target
 
 [Service]
-EnvironmentFile=/etc/sysconfig/airflow
+EnvironmentFile=<%= @env_path %>
 User=<%= @user %>
 Group=<%= @group %>
 ExecStart=<%= @bin_path %>/airflow kerberos --pid <%= @run_path %>/airflow-kerberos.pid

--- a/templates/default/init_system/systemd/airflow-scheduler.service.erb
+++ b/templates/default/init_system/systemd/airflow-scheduler.service.erb
@@ -17,7 +17,7 @@ Description=Airflow scheduler daemon
 After=network.target
 
 [Service]
-EnvironmentFile=/etc/sysconfig/airflow
+EnvironmentFile=<%= @env_path %>
 User=<%= @user %>
 Group=<%= @group %>
 ExecStart=<%= @bin_path %>/airflow scheduler --pid <%= @run_path %>/airflow-scheduler.pid

--- a/templates/default/init_system/systemd/airflow-webserver.service.erb
+++ b/templates/default/init_system/systemd/airflow-webserver.service.erb
@@ -17,7 +17,7 @@ Description=Airflow webserver daemon
 After=network.target
 
 [Service]
-EnvironmentFile=/etc/sysconfig/airflow
+EnvironmentFile=<%= @env_path %>
 User=<%= @user %>
 Group=<%= @group %>
 ExecStart=<%= @bin_path %>/airflow webserver --pid <%= @run_path %>/airflow-webserver.pid

--- a/templates/default/init_system/systemd/airflow-worker.service.erb
+++ b/templates/default/init_system/systemd/airflow-worker.service.erb
@@ -17,7 +17,7 @@ Description=Airflow worker daemon
 After=network.target
 
 [Service]
-EnvironmentFile=/etc/sysconfig/airflow
+EnvironmentFile=<%= @env_path %>
 User=<%= @user %>
 Group=<%= @group %>
 ExecStart=<%= @bin_path %>/airflow worker --pid <%= @run_path %>/airflow-worker.pid


### PR DESCRIPTION
Hi,

This PR enables support for Ubuntu 16.04 with the intent of not breaking compatibility with Ubuntu 14.04.

It supports `systemd` which is now the default for Ubuntu. For this to work a user would have to specify that they want to run `systemd` on `ubuntu`.
