### PR TITLE
Correct the PID path for the scheduler

### DIFF
--- a/templates/default/init_system/upstart/airflow-scheduler.conf.erb
+++ b/templates/default/init_system/upstart/airflow-scheduler.conf.erb
@@ -31,6 +31,6 @@ pre-start script
 end script
 
 pre-stop script
-	rm <%= @run_path %>/airflow-webserver.pid
+	rm <%= @run_path %>/airflow-scheduler.pid
     echo "[`date`] Airflow scheduler shutting down..."
 end script


### PR DESCRIPTION
The scheduler upstart script is trying to remove the webserver PID file.