### PR TITLE
Created attribute for Airflow package name

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 # User configuration
+default["airflow"]["airflow_package"] = 'airflow' # 'apache-airflow' for version >= 1.8.2
 default["airflow"]["version"] = nil
 default["airflow"]["user"] = "airflow"
 default["airflow"]["group"] = "airflow"

--- a/recipes/packages.rb
+++ b/recipes/packages.rb
@@ -15,7 +15,7 @@
 python_runtime node["airflow"]["python_runtime"] do
   version node["airflow"]["python_version"]
   provider :system
-  pip_version node["airflow"]["pip_version"]  
+  pip_version node["airflow"]["pip_version"]
 end
 
 # Obtain the current platform name
@@ -64,7 +64,7 @@ dependencies_to_install.each do |value|
 end
 
 # Install Airflow
-python_package 'airflow' do
+python_package node['airflow']['airflow_package'] do
   version node['airflow']['version']
 end
 


### PR DESCRIPTION
Since >1.8.1 airflow has been renamed to apache-airflow. I have created an attribute so we can switch between both package name.

xref: https://github.com/apache/incubator-airflow/blob/master/UPDATING.md#airflow-181